### PR TITLE
Define unicode() for Python 3

### DIFF
--- a/share/extensions/inkex.py
+++ b/share/extensions/inkex.py
@@ -48,6 +48,10 @@ u'xlink'    :u'http://www.w3.org/1999/xlink',
 u'xml'      :u'http://www.w3.org/XML/1998/namespace'
 }
 
+try:
+  unicode        # Python 2
+except NameError:
+  unicode = str  # Python 3
 
 def localize():
     domain = 'inkscape'


### PR DESCRIPTION
__unicode()__ was removed from Python 3 because all strs are Unicode. This PR does not modify Python 2 functionality.